### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.4](https://github.com/mrkjdy/sudoku_machine/compare/v0.1.3...v0.1.4) - 2025-02-17
+
+### Other
+
+- use toJSON to stringify release plz release output (#30)
+
 ## [0.1.3](https://github.com/mrkjdy/sudoku_machine/compare/v0.1.2...v0.1.3) - 2025-02-17
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4348,7 +4348,7 @@ dependencies = [
 
 [[package]]
 name = "sudoku_machine"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "arboard",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sudoku_machine"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "A Sudoku game built with Bevy"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `sudoku_machine`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/mrkjdy/sudoku_machine/compare/v0.1.3...v0.1.4) - 2025-02-17

### Other

- use toJSON to stringify release plz release output (#30)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).