### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.0](https://github.com/mrkjdy/sudoku_machine/compare/v0.1.8...v0.2.0) - 2025-08-03
+
+### Added
+
+- use symbols and font for nav button ([#67](https://github.com/mrkjdy/sudoku_machine/pull/67))
+
+### Fixed
+
+- make fps counter actually readable ([#83](https://github.com/mrkjdy/sudoku_machine/pull/83))
+- couple issues after 0.16 upgrade ([#65](https://github.com/mrkjdy/sudoku_machine/pull/65))
+- disable BorderlessFullscreen on wasm ([#49](https://github.com/mrkjdy/sudoku_machine/pull/49))
+
+### Other
+
+- *(deps)* bump rand from 0.9.1 to 0.9.2 ([#82](https://github.com/mrkjdy/sudoku_machine/pull/82))
+- *(deps)* bump strum_macros from 0.27.1 to 0.27.2 ([#81](https://github.com/mrkjdy/sudoku_machine/pull/81))
+- *(deps)* bump strum from 0.27.1 to 0.27.2 ([#80](https://github.com/mrkjdy/sudoku_machine/pull/80))
+- bump arboard to 3.6.0 ([#84](https://github.com/mrkjdy/sudoku_machine/pull/84))
+- *(deps)* bump num_enum from 0.7.3 to 0.7.4 ([#78](https://github.com/mrkjdy/sudoku_machine/pull/78))
+- create issues for TODOs ([#68](https://github.com/mrkjdy/sudoku_machine/pull/68))
+- *(deps)* bump bevy from 0.16.0 to 0.16.1 ([#77](https://github.com/mrkjdy/sudoku_machine/pull/77))
+- split up themed ([#66](https://github.com/mrkjdy/sudoku_machine/pull/66))
+- *(deps)* bump getrandom from 0.3.2 to 0.3.3 ([#64](https://github.com/mrkjdy/sudoku_machine/pull/64))
+- upgrade to bevy 0.16 ([#63](https://github.com/mrkjdy/sudoku_machine/pull/63))
+- *(deps)* bump rand from 0.9.0 to 0.9.1 ([#60](https://github.com/mrkjdy/sudoku_machine/pull/60))
+- add CODEOWNERS ([#59](https://github.com/mrkjdy/sudoku_machine/pull/59))
+- *(deps)* bump divan from 0.1.17 to 0.1.18 ([#54](https://github.com/mrkjdy/sudoku_machine/pull/54))
+- *(deps)* bump arboard from 3.4.1 to 3.5.0 ([#53](https://github.com/mrkjdy/sudoku_machine/pull/53))
+- *(deps)* bump getrandom from 0.3.1 to 0.3.2 ([#52](https://github.com/mrkjdy/sudoku_machine/pull/52))
+- *(deps)* bump crossbeam-channel from 0.5.14 to 0.5.15 ([#55](https://github.com/mrkjdy/sudoku_machine/pull/55))
+- only cargo build on non-release events ([#58](https://github.com/mrkjdy/sudoku_machine/pull/58))
+- don't install code signing cert on dependabot ([#56](https://github.com/mrkjdy/sudoku_machine/pull/56))
+- cargo update ([#50](https://github.com/mrkjdy/sudoku_machine/pull/50))
+
 ## [0.1.8](https://github.com/mrkjdy/sudoku_machine/compare/v0.1.7...v0.1.8) - 2025-02-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4681,7 +4681,7 @@ dependencies = [
 
 [[package]]
 name = "sudoku_machine"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "arboard",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sudoku_machine"
-version = "0.1.8"
+version = "0.2.0"
 edition = "2021"
 description = "A Sudoku game built with Bevy"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `sudoku_machine`: 0.1.8 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `sudoku_machine` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant ThemedFontWeight:Symbolic in /tmp/.tmpvt02ya/sudoku_machine/src/plugins/common/theme/text.rs:13

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/function_missing.ron

Failed in:
  function sudoku_machine::plugins::common::widgets::text_input::text_input_plugin, previously in file /tmp/.tmph2p1Ac/sudoku_machine/src/plugins/common/widgets/text_input.rs:13
  function sudoku_machine::plugins::common::widgets::dropdown::dropdown_plugin, previously in file /tmp/.tmph2p1Ac/sudoku_machine/src/plugins/common/widgets/dropdown.rs:8

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/module_missing.ron

Failed in:
  mod sudoku_machine::plugins::common::widgets::dropdown, previously in file /tmp/.tmph2p1Ac/sudoku_machine/src/plugins/common/widgets/dropdown.rs:1
  mod sudoku_machine::plugins::common::widgets, previously in file /tmp/.tmph2p1Ac/sudoku_machine/src/plugins/common/widgets/mod.rs:1
  mod sudoku_machine::plugins::common::widgets::text_input, previously in file /tmp/.tmph2p1Ac/sudoku_machine/src/plugins/common/widgets/text_input.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct sudoku_machine::plugins::common::widgets::dropdown::DropdownContainer, previously in file /tmp/.tmph2p1Ac/sudoku_machine/src/plugins/common/widgets/dropdown.rs:23
  struct sudoku_machine::plugins::common::widgets::text_input::TextInputCursor, previously in file /tmp/.tmph2p1Ac/sudoku_machine/src/plugins/common/widgets/text_input.rs:56
  struct sudoku_machine::plugins::common::theme::node::ListItemButton, previously in file /tmp/.tmph2p1Ac/sudoku_machine/src/plugins/common/theme/node.rs:7
  struct sudoku_machine::plugins::common::widgets::text_input::TextInputContainer, previously in file /tmp/.tmph2p1Ac/sudoku_machine/src/plugins/common/widgets/text_input.rs:28
  struct sudoku_machine::plugins::common::widgets::text_input::TextInputWidget, previously in file /tmp/.tmph2p1Ac/sudoku_machine/src/plugins/common/widgets/text_input.rs:43
  struct sudoku_machine::plugins::common::theme::Themed, previously in file /tmp/.tmph2p1Ac/sudoku_machine/src/plugins/common/theme/mod.rs:69
  struct sudoku_machine::plugins::common::widgets::dropdown::DropdownWidget, previously in file /tmp/.tmph2p1Ac/sudoku_machine/src/plugins/common/widgets/dropdown.rs:52

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_missing.ron

Failed in:
  trait sudoku_machine::plugins::common::widgets::Spawn, previously in file /tmp/.tmph2p1Ac/sudoku_machine/src/plugins/common/widgets/mod.rs:6
  trait sudoku_machine::plugins::common::widgets::Spawnable, previously in file /tmp/.tmph2p1Ac/sudoku_machine/src/plugins/common/widgets/mod.rs:16
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/mrkjdy/sudoku_machine/compare/v0.1.8...v0.2.0) - 2025-08-03

### Added

- use symbols and font for nav button ([#67](https://github.com/mrkjdy/sudoku_machine/pull/67))

### Fixed

- make fps counter actually readable ([#83](https://github.com/mrkjdy/sudoku_machine/pull/83))
- couple issues after 0.16 upgrade ([#65](https://github.com/mrkjdy/sudoku_machine/pull/65))
- disable BorderlessFullscreen on wasm ([#49](https://github.com/mrkjdy/sudoku_machine/pull/49))

### Other

- *(deps)* bump rand from 0.9.1 to 0.9.2 ([#82](https://github.com/mrkjdy/sudoku_machine/pull/82))
- *(deps)* bump strum_macros from 0.27.1 to 0.27.2 ([#81](https://github.com/mrkjdy/sudoku_machine/pull/81))
- *(deps)* bump strum from 0.27.1 to 0.27.2 ([#80](https://github.com/mrkjdy/sudoku_machine/pull/80))
- bump arboard to 3.6.0 ([#84](https://github.com/mrkjdy/sudoku_machine/pull/84))
- *(deps)* bump num_enum from 0.7.3 to 0.7.4 ([#78](https://github.com/mrkjdy/sudoku_machine/pull/78))
- create issues for TODOs ([#68](https://github.com/mrkjdy/sudoku_machine/pull/68))
- *(deps)* bump bevy from 0.16.0 to 0.16.1 ([#77](https://github.com/mrkjdy/sudoku_machine/pull/77))
- split up themed ([#66](https://github.com/mrkjdy/sudoku_machine/pull/66))
- *(deps)* bump getrandom from 0.3.2 to 0.3.3 ([#64](https://github.com/mrkjdy/sudoku_machine/pull/64))
- upgrade to bevy 0.16 ([#63](https://github.com/mrkjdy/sudoku_machine/pull/63))
- *(deps)* bump rand from 0.9.0 to 0.9.1 ([#60](https://github.com/mrkjdy/sudoku_machine/pull/60))
- add CODEOWNERS ([#59](https://github.com/mrkjdy/sudoku_machine/pull/59))
- *(deps)* bump divan from 0.1.17 to 0.1.18 ([#54](https://github.com/mrkjdy/sudoku_machine/pull/54))
- *(deps)* bump arboard from 3.4.1 to 3.5.0 ([#53](https://github.com/mrkjdy/sudoku_machine/pull/53))
- *(deps)* bump getrandom from 0.3.1 to 0.3.2 ([#52](https://github.com/mrkjdy/sudoku_machine/pull/52))
- *(deps)* bump crossbeam-channel from 0.5.14 to 0.5.15 ([#55](https://github.com/mrkjdy/sudoku_machine/pull/55))
- only cargo build on non-release events ([#58](https://github.com/mrkjdy/sudoku_machine/pull/58))
- don't install code signing cert on dependabot ([#56](https://github.com/mrkjdy/sudoku_machine/pull/56))
- cargo update ([#50](https://github.com/mrkjdy/sudoku_machine/pull/50))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).