### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.1](https://github.com/mrkjdy/sudoku_machine/compare/v0.2.0...v0.2.1) - 2025-08-16
+
+### Other
+
+- *(deps)* bump actions/download-artifact from 4 to 5 ([#85](https://github.com/mrkjdy/sudoku_machine/pull/85))
+
 ## [0.2.0](https://github.com/mrkjdy/sudoku_machine/compare/v0.1.8...v0.2.0) - 2025-08-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4681,7 +4681,7 @@ dependencies = [
 
 [[package]]
 name = "sudoku_machine"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arboard",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sudoku_machine"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "A Sudoku game built with Bevy"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `sudoku_machine`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/mrkjdy/sudoku_machine/compare/v0.2.0...v0.2.1) - 2025-08-16

### Other

- *(deps)* bump actions/download-artifact from 4 to 5 ([#85](https://github.com/mrkjdy/sudoku_machine/pull/85))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).