### PR TITLE
fix: hide nav on home

### DIFF
--- a/src/plugins/menu/home.rs
+++ b/src/plugins/menu/home.rs
@@ -50,7 +50,7 @@ enum HomeMenuButton {
 }
 
 fn home_menu_setup(mut nav_state: ResMut<NextState<NavState>>, mut commands: Commands) {
-    nav_state.set(NavState::Exit);
+    nav_state.set(NavState::Hidden);
 
     let title_bundle = (
         Text::new(APP_TITLE),


### PR DESCRIPTION
The exit button doesn't really work well on wasm and all targets should provide a built-in way to close windows, so I removed it and made the nav button hidden on the home screen.