### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.0](https://github.com/mrkjdy/sudoku_machine/compare/v0.3.0...v0.4.0) - 2026-04-14
+
+### Added
+
+- classic ui ([#93](https://github.com/mrkjdy/sudoku_machine/pull/93))
+
+### Other
+
+- *(deps)* bump rand from 0.9.2 to 0.9.3 ([#131](https://github.com/mrkjdy/sudoku_machine/pull/131))
+- *(deps)* bump actions/upload-pages-artifact from 4 to 5 ([#130](https://github.com/mrkjdy/sudoku_machine/pull/130))
+- *(deps)* bump actions/configure-pages from 5 to 6 ([#129](https://github.com/mrkjdy/sudoku_machine/pull/129))
+- *(deps)* bump actions/deploy-pages from 4 to 5 ([#128](https://github.com/mrkjdy/sudoku_machine/pull/128))
+- *(deps)* bump mshick/add-pr-comment from 2 to 3 ([#127](https://github.com/mrkjdy/sudoku_machine/pull/127))
+- *(deps)* bump actions/upload-artifact from 6 to 7 ([#126](https://github.com/mrkjdy/sudoku_machine/pull/126))
+- *(deps)* bump actions/download-artifact from 7 to 8 ([#125](https://github.com/mrkjdy/sudoku_machine/pull/125))
+- *(deps)* bump bytes from 1.10.1 to 1.11.1 ([#124](https://github.com/mrkjdy/sudoku_machine/pull/124))
+- *(deps)* bump actions/upload-artifact from 5 to 6 ([#117](https://github.com/mrkjdy/sudoku_machine/pull/117))
+- *(deps)* bump actions/download-artifact from 6 to 7 ([#118](https://github.com/mrkjdy/sudoku_machine/pull/118))
+- *(deps)* bump wasm-bindgen-futures from 0.4.55 to 0.4.56 ([#116](https://github.com/mrkjdy/sudoku_machine/pull/116))
+- *(deps)* bump actions/checkout from 5 to 6 ([#115](https://github.com/mrkjdy/sudoku_machine/pull/115))
+- document run commands and wasm-bindgen stuff ([#113](https://github.com/mrkjdy/sudoku_machine/pull/113))
+- disable non-classic modes for now ([#110](https://github.com/mrkjdy/sudoku_machine/pull/110))
+- *(deps)* bump wasm-bindgen-futures from 0.4.54 to 0.4.55 ([#107](https://github.com/mrkjdy/sudoku_machine/pull/107))
+- optimize caching ([#109](https://github.com/mrkjdy/sudoku_machine/pull/109))
+- *(deps)* bump indoc from 2.0.6 to 2.0.7 ([#103](https://github.com/mrkjdy/sudoku_machine/pull/103))
+- switch x86 macos runner to macos-15-intel ([#108](https://github.com/mrkjdy/sudoku_machine/pull/108))
+- *(deps)* bump actions/upload-artifact from 4 to 5 ([#106](https://github.com/mrkjdy/sudoku_machine/pull/106))
+- *(deps)* bump actions/download-artifact from 5 to 6 ([#105](https://github.com/mrkjdy/sudoku_machine/pull/105))
+- *(deps)* bump getrandom from 0.3.3 to 0.3.4 ([#101](https://github.com/mrkjdy/sudoku_machine/pull/101))
+- *(deps)* bump num_enum from 0.7.4 to 0.7.5 ([#102](https://github.com/mrkjdy/sudoku_machine/pull/102))
+
 ## [0.3.0](https://github.com/mrkjdy/sudoku_machine/compare/v0.2.0...v0.3.0) - 2025-09-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "sudoku_machine"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arboard",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sudoku_machine"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "A Sudoku game built with Bevy"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `sudoku_machine`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `sudoku_machine` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum sudoku_machine::plugins::menu::MenuState, previously in file /tmp/.tmpZwmpSI/sudoku_machine/src/plugins/menu/mod.rs:22
  enum sudoku_machine::plugins::game::GameState, previously in file /tmp/.tmpZwmpSI/sudoku_machine/src/plugins/game/mod.rs:44
  enum sudoku_machine::plugins::game::PuzzleType, previously in file /tmp/.tmpZwmpSI/sudoku_machine/src/plugins/game/mod.rs:14
  enum sudoku_machine::AppState, previously in file /tmp/.tmpZwmpSI/sudoku_machine/src/lib.rs:30

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function sudoku_machine::plugins::game::game_plugin, previously in file /tmp/.tmpZwmpSI/sudoku_machine/src/plugins/game/mod.rs:50
  function sudoku_machine::despawn_component, previously in file /tmp/.tmpZwmpSI/sudoku_machine/src/lib.rs:37
  function sudoku_machine::plugins::menu::menu_plugin, previously in file /tmp/.tmpZwmpSI/sudoku_machine/src/plugins/menu/mod.rs:11

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod sudoku_machine::plugins::game, previously in file /tmp/.tmpZwmpSI/sudoku_machine/src/plugins/game/mod.rs:1
  mod sudoku_machine::grids::classic, previously in file /tmp/.tmpZwmpSI/sudoku_machine/src/grids/classic.rs:1
  mod sudoku_machine::plugins::menu, previously in file /tmp/.tmpZwmpSI/sudoku_machine/src/plugins/menu/mod.rs:1
  mod sudoku_machine::grids, previously in file /tmp/.tmpZwmpSI/sudoku_machine/src/lib.rs:16

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  PIXELS_PER_CH in file /tmp/.tmpZwmpSI/sudoku_machine/src/plugins/menu/mod.rs:31

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct sudoku_machine::grids::classic::BoxIter, previously in file /tmp/.tmpZwmpSI/sudoku_machine/src/grids/classic.rs:34
  struct sudoku_machine::plugins::game::PuzzleTypeIter, previously in file /tmp/.tmpZwmpSI/sudoku_machine/src/plugins/game/mod.rs:12
  struct sudoku_machine::PuzzleSettings, previously in file /tmp/.tmpZwmpSI/sudoku_machine/src/lib.rs:44
  struct sudoku_machine::puzzles::classic::ClassicPuzzle, previously in file /tmp/.tmpZwmpSI/sudoku_machine/src/puzzles/classic.rs:20
  struct sudoku_machine::grids::classic::ColIter, previously in file /tmp/.tmpZwmpSI/sudoku_machine/src/grids/classic.rs:6
  struct sudoku_machine::grids::classic::ClassicGrid, previously in file /tmp/.tmpZwmpSI/sudoku_machine/src/grids/classic.rs:4
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/mrkjdy/sudoku_machine/compare/v0.3.0...v0.4.0) - 2026-04-14

### Added

- classic ui ([#93](https://github.com/mrkjdy/sudoku_machine/pull/93))

### Other

- *(deps)* bump rand from 0.9.2 to 0.9.3 ([#131](https://github.com/mrkjdy/sudoku_machine/pull/131))
- *(deps)* bump actions/upload-pages-artifact from 4 to 5 ([#130](https://github.com/mrkjdy/sudoku_machine/pull/130))
- *(deps)* bump actions/configure-pages from 5 to 6 ([#129](https://github.com/mrkjdy/sudoku_machine/pull/129))
- *(deps)* bump actions/deploy-pages from 4 to 5 ([#128](https://github.com/mrkjdy/sudoku_machine/pull/128))
- *(deps)* bump mshick/add-pr-comment from 2 to 3 ([#127](https://github.com/mrkjdy/sudoku_machine/pull/127))
- *(deps)* bump actions/upload-artifact from 6 to 7 ([#126](https://github.com/mrkjdy/sudoku_machine/pull/126))
- *(deps)* bump actions/download-artifact from 7 to 8 ([#125](https://github.com/mrkjdy/sudoku_machine/pull/125))
- *(deps)* bump bytes from 1.10.1 to 1.11.1 ([#124](https://github.com/mrkjdy/sudoku_machine/pull/124))
- *(deps)* bump actions/upload-artifact from 5 to 6 ([#117](https://github.com/mrkjdy/sudoku_machine/pull/117))
- *(deps)* bump actions/download-artifact from 6 to 7 ([#118](https://github.com/mrkjdy/sudoku_machine/pull/118))
- *(deps)* bump wasm-bindgen-futures from 0.4.55 to 0.4.56 ([#116](https://github.com/mrkjdy/sudoku_machine/pull/116))
- *(deps)* bump actions/checkout from 5 to 6 ([#115](https://github.com/mrkjdy/sudoku_machine/pull/115))
- document run commands and wasm-bindgen stuff ([#113](https://github.com/mrkjdy/sudoku_machine/pull/113))
- disable non-classic modes for now ([#110](https://github.com/mrkjdy/sudoku_machine/pull/110))
- *(deps)* bump wasm-bindgen-futures from 0.4.54 to 0.4.55 ([#107](https://github.com/mrkjdy/sudoku_machine/pull/107))
- optimize caching ([#109](https://github.com/mrkjdy/sudoku_machine/pull/109))
- *(deps)* bump indoc from 2.0.6 to 2.0.7 ([#103](https://github.com/mrkjdy/sudoku_machine/pull/103))
- switch x86 macos runner to macos-15-intel ([#108](https://github.com/mrkjdy/sudoku_machine/pull/108))
- *(deps)* bump actions/upload-artifact from 4 to 5 ([#106](https://github.com/mrkjdy/sudoku_machine/pull/106))
- *(deps)* bump actions/download-artifact from 5 to 6 ([#105](https://github.com/mrkjdy/sudoku_machine/pull/105))
- *(deps)* bump getrandom from 0.3.3 to 0.3.4 ([#101](https://github.com/mrkjdy/sudoku_machine/pull/101))
- *(deps)* bump num_enum from 0.7.4 to 0.7.5 ([#102](https://github.com/mrkjdy/sudoku_machine/pull/102))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).